### PR TITLE
Meta-data based file filtering prior to Parser module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## [TBD] - TBD
+- Added the ability to filter files prior to passing to the parser based on the meta-data file's contents.  The parameters that are checked are SendingSite, PayloadType, PayloadFormat, DataSensitivity, SharingRestrictions, ReconPolicy, and SentTimestamp.
+- These configuration filter parameters are not required in the file and if not present are ignored when checking the file against filters.
+
 ## [3.4.1] - 2017-09-26
 - Added a configuration for log rotation. When enabled, log files will be appended with the current date when written. This feature was requested to make it easier to enable processes that will rotate out log files after a certain time, make the files easier to parse, and to break up the logs so that they do not grow to be so large. Looking into making the format of the rotation more configurable and possibly a feature for LQMT to do the actual file rotation. 
 - Added this changelog. All changes were previously detailed in git commit messages. This practice will continue, but this file will make it easier to scan for changes and will be more detailed about the actual changes. 

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -15,6 +15,30 @@ Setting        | Explanation
 `post_process_location` | Used in conjunction with the `track` post process option. Used to specify a custom location for where your track file will be placed. 
 
 
+# Source Filters
+This setting specifies meta-data file based filtering of files before being processed.  This allows a user to include or exclude files from being parsed and utilized in tools.  The parameters are not required and do not need to be present in the configuration file.
+
+    [[Source.Filters]]
+        site_includes = [ 'SITE1' ]
+        site_excludes = [ 'SITE2' ]
+        payload_types = [ 'Alert' ]
+        payload_formats = [ 'STIX' ]
+        sensitivities = [ 'noSensitivity' ]
+        restrictions = [ 'WHITE' ]
+        reconnaissance = [ 'Touch' ]
+        max_file_age = "2 mon"
+
+Setting        | Explanation
+----------------------: | :----------
+`site_includes`     | (Optional) A list of `SendingSite` entries that are allowed.  An empty list or no entry results in `True` to not filter for this setting.
+`site_excludes`     | (Optional) A list of `SendingSite` entries that are to be filtered out.  An empty list or no entry results in `True` to not filter for this setting. 
+`payload_types`     | (Optional) A list of `PayloadType` entries that are allowed (e.g. `Alert`, `Report`, etc).  An empty list or no entry results in `True` to not filter for this setting. 
+`payload_formats`   | (Optional) A list of `PayloadFormat` entries that are allowed (e.g. `STIX`, `Cfm13Alert`, etc).  An empty list or no entry results in `True` to not filter for this setting.
+`sensitivities`     | (Optional) A list of `DataSensitivity` entries that are allowed (e.g. `ouo`, `noSensitivity`, etc).  An empty list or no entry results in `True` to not filter for this setting.
+`restrictions`      | (Optional) A list of `SharingRestrictions` entries that are allowed (e.g. `WHITE`, `AMBER`, etc).  An empty list or no entry results in `True` to not filter for this setting.
+`reconnaissance`    | (Optional) A list of `ReconPolicy` entries that are allowed (e.g. `Touch`, `NoTouch`, etc).  An empty list or no entry results in `True` to not filter for this setting.
+`max_file_age`      | (Optional) A string formatted `%d %s` for the maximum age file to be processed.  This supports an offset for seconds `'s', 'sec', 'secs', 'second', 'seconds'`, minutes `'m', 'min', 'minute', 'minutes'`, hours `'h', 'hr', 'hrs', 'hour', 'hours'`, days `'d', 'day', 'days'`, weeks `'w', 'week', 'weeks'`, months `'mon', 'month', 'months'`, years `'y', 'yr', 'yrs', 'year', 'years'`.
+
 # Parsers
 LQMT uses special parsers for each type of alert file to get all the data into one common format. By default, the majority of the parsers are enabled, but some parsers are disabled by default. Detailed below are the types of parsers LQMT uses, which are enabled by default, and how you can configure LQMT to disable or enable them. 
 

--- a/lqmt/lqm/config.py
+++ b/lqmt/lqm/config.py
@@ -9,6 +9,7 @@ import toml
 from lqmt.lqm.exceptions import ConfigurationError
 from lqmt.lqm.logging import LQMLogging
 from lqmt.lqm.sourcedir import DirectorySource
+from lqmt.lqm.sourcefilter import SourceFilters
 from lqmt.lqm.systemconfig import SystemConfig
 from lqmt.lqm.tool import ToolChain
 from lqmt.whitelist.master import MasterWhitelist
@@ -46,6 +47,7 @@ class LQMToolConfig(object):
         self._loggingCfg = None
         self._toolsList = []
         self._userConfig = {}
+        self._pre_filters = []
 
         # load config files
         self._loadSystemConfig()
@@ -248,6 +250,8 @@ class LQMToolConfig(object):
             for cfg in srcCfgs[key]:
                 if key == "Directory":
                     self._sources.append(DirectorySource(cfg))
+                elif key == "Filters":
+                    self._pre_filters = SourceFilters(cfg)
 
     def getSources(self):
         return self._sources
@@ -268,3 +272,6 @@ class LQMToolConfig(object):
         :return: Returns a list of tools that are currently active in the toolchain.
         """
         return self._toolsList
+
+    def getSourceFilters(self):
+        return self._pre_filters

--- a/lqmt/lqm/controller.py
+++ b/lqmt/lqm/controller.py
@@ -39,7 +39,12 @@ class LQMToolController:
             for data, unparsed_metadata in alert_files:
                 metadata = self._parsemeta(unparsed_metadata)
                 if metadata:
-                    self._parse(data, metadata)
+                    filters = self._config.getSourceFilters()
+                    if filters:
+                        if filters.checkAllFilters(metadata):
+                            self._parse(data, metadata)
+                    else:
+                        self._parse(data, metadata)
         self._chainCleanup()
 
     def pull(self):

--- a/lqmt/lqm/sourcefilter.py
+++ b/lqmt/lqm/sourcefilter.py
@@ -1,0 +1,254 @@
+import arrow
+from lqmt.lqm.exceptions import ConfigurationError
+
+class SourceFilters(object):
+    def __init__(self, config):
+        """
+        Initialization function for class handling file source filters
+        :param config: Dictionary of the user configuration section for Sources.Filters
+        :return: None
+        """
+        self._site_includes = []
+        self._site_excludes = []
+        self._payload_types = []
+        self._payload_formats = []
+        self._sensitivities = []
+        self._restrictions = []
+        self._reconnaissance = []
+        self._max_file_age = None
+
+        if 'site_includes' in config:
+            self._site_includes = self.__list_lower(config['site_includes'])
+        if 'site_excludes' in config:
+            self._site_excludes = self.__list_lower(config['site_excludes'])
+        if 'payload_types' in config:
+            self._payload_types = self.__list_lower(config['payload_types'])
+        if 'payload_formats' in config:
+            self._payload_formats = self.__list_lower(config['payload_formats'])
+        if 'sensitivities' in config:
+            self._sensitivities = self.__list_lower(config['sensitivities'])
+        if 'restrictions' in config:
+            self._restrictions = self.__list_lower(config['restrictions'])
+        if 'reconnaissance' in config:
+            self._reconnaissance = self.__list_lower(config['reconnaissance'])
+        if 'max_file_age' in config:
+            self._max_file_age = config['max_file_age']
+
+    def __list_lower(self, value):
+        """
+        Lower cases a list that is provided.
+        :param value: List of strings to be converted to lower case
+        :return ret: Converted list
+        """
+        ret = []
+
+        for i in value:
+            ret.append(i.lower())
+
+        return ret
+
+    def checkAllFilters(self, metafile):
+        """
+        Performs all the available filter checks against the file meta-data.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        if not self.checkSendingSite(metafile):
+            return False
+        if not self.checkPayloadType(metafile):
+            return False
+        if not self.checkPayloadFormat(metafile):
+            return False
+        if not self.checkDataSensitivity(metafile):
+            return False
+        if not self.checkSharingRestrictions(metafile):
+            return False
+        if not self.checkReconPolicy(metafile):
+            return False
+        if not self.checkFileAge(metafile):
+            return False
+
+        return True
+
+    def checkSendingSite(self, metafile):
+        """
+        Checks the Includes and Excludes list against the sending site in the meta data.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+
+        if metafile is None:
+            return False
+
+        # Check the Sending Sites
+        if 'SendingSite' in metafile:
+            if metafile['SendingSite'].lower() in self._site_includes or not self._site_includes:
+                ret = True
+            # if in both includes and excludes, will filter out the file
+            if metafile['SendingSite'].lower() in self._site_excludes and self._site_excludes:
+                ret = False
+
+        return ret
+
+    def checkPayloadType(self, metafile):
+        """
+        Checks the Payload Type against configured list.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+
+        if metafile is None:
+            return False
+
+        if not self._payload_types:
+            return True
+
+        # Check the PayloadType
+        if 'PayloadType' in metafile:
+            if metafile['PayloadType'].lower() in self._payload_types:
+                ret = True
+
+        return ret
+
+    def checkPayloadFormat(self, metafile):
+        """
+        Checks the Payload Format against configured list.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+
+        if metafile is None:
+            return False
+
+        if not self._payload_formats:
+            return True
+
+        # Check the PayloadFormat
+        if 'PayloadFormat' in metafile:
+            if metafile['PayloadFormat'].lower() in self._payload_formats:
+                ret = True
+
+        return ret
+
+    def checkDataSensitivity(self,
+                             metafile):
+        """
+        Checks the Data Sensitivity against configured list.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+
+        if metafile is None:
+            return False
+
+        if not self._sensitivities:
+            return True
+
+        # Check the DataSensitivity
+        if 'DataSensitivity' in metafile:
+            if metafile['DataSensitivity'].lower() in self._sensitivities:
+                ret = True
+
+        return ret
+
+    def checkSharingRestrictions(self, metafile):
+        """
+        Checks the Sharing Restrictions against configured list.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+
+        if metafile is None:
+            return False
+
+        if not self._restrictions:
+            return True
+
+        # Check the SharingRestrictions
+        if 'SharingRestrictions' in metafile:
+            if metafile['SharingRestrictions'].lower() in self._restrictions:
+                ret = True
+
+        return ret
+
+    def checkReconPolicy(self, metafile):
+        """
+        Checks the Reconnaissance Policy against configured list.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+
+        if metafile is None:
+            return False
+
+        if not self._reconnaissance:
+            return True
+
+        # Check the ReconPolicy
+        if 'ReconPolicy' in metafile:
+            if metafile['ReconPolicy'].lower() in self._reconnaissance:
+                ret = True
+
+        return ret
+
+    def checkFileAge(self, metafile):
+        """
+        Checks the Sent Timestamp against a shifted date/time for maximum file age.
+        :param metafile: Meta-data file to compare to the filter parameters
+        :return: Boolean for whether file has passed the pre-filtering settings
+        """
+        ret = False
+        now = arrow.utcnow()
+        filetime = None
+        num = 0
+        second = ['s', 'sec', 'secs', 'second', 'seconds']
+        minute = ['m', 'min', 'minute', 'minutes']
+        hour = ['h', 'hr', 'hrs', 'hour', 'hours']
+        day = ['d', 'day', 'days']
+        week = ['w', 'week', 'weeks']
+        month = ['mon', 'month', 'months']
+        year = ['y', 'yr', 'yrs', 'year', 'years']
+
+        if metafile is None:
+            return False
+
+        if self._max_file_age is None:
+            return True
+
+        cols = self._max_file_age.split(' ')
+        if cols[0].isdigit():
+            num = -1 * int(cols[0])
+        else:
+            raise ConfigurationError(
+                "Unable to parse file age \"{0}\" expecting %d %s format (e.g. 2 weeks)".format(self._max_file_age))
+
+        if cols[1] in second:
+            shift = now.shift(seconds=num)
+        elif cols[1] in minute:
+            shift = now.shift(minutes=num)
+        elif cols[1] in hour:
+            shift = now.shift(hours=num)
+        elif cols[1] in day:
+            shift = now.shift(days=num)
+        elif cols[1] in week:
+            shift = now.shift(weeks=num)
+        elif cols[1] in month:
+            shift = now.shift(months=num)
+        elif cols[1] in year:
+            shift = now.shift(years=num)
+        else:
+            raise ConfigurationError(
+                "Unable to determine time string in \"{0}\". Refer to documentation for accepted time strings.".format(self._max_file_age))
+
+        if 'SentTimestamp' in metafile:
+            filetime = arrow.get(metafile['SentTimestamp'])
+            if filetime > shift:
+                ret = True
+
+        return ret

--- a/lqmt/test/configuration_test.py
+++ b/lqmt/test/configuration_test.py
@@ -49,6 +49,16 @@ class TestConfiguration(TestCase):
         self.assertEquals(sources._dirs, [self.alerts.replace("\\\\", "\\")])
         self.assertIsNone(sources.files_to_process)
 
+    def test_user_source_filters(self):
+        filters = self.user_config.getSourceFilters()
+        self.assertIsNotNone(filters._site_includes)
+        self.assertIsNotNone(filters._site_excludes)
+        self.assertIsNotNone(filters._payload_formats)
+        self.assertIsNotNone(filters._sensitivities)
+        self.assertIsNotNone(filters._restrictions)
+        self.assertIsNotNone(filters._reconnaissance)
+        self.assertIsNotNone(filters._max_file_age)
+
     def test_user_whitelist(self):
         whitelist = self.user_config.getWhitelist()
         self.assertIsNotNone(whitelist)

--- a/lqmt/test/filter_test.py
+++ b/lqmt/test/filter_test.py
@@ -1,0 +1,211 @@
+import toml
+import json
+import arrow
+from unittest import TestCase, main
+from lqmt.test.test_data.filters.filter_configs import TESTCONFIG1
+from lqmt.test.test_data.filters.filter_inputs import INPUT1
+from lqmt.lqm.sourcefilter import SourceFilters
+
+
+class TestFilters(TestCase):
+    def setUp(self):
+        self.user_config = toml.loads(TESTCONFIG1)
+        self.filters = SourceFilters(self.user_config['Source']['Filters'][0])
+
+    def test_all_filters(self):
+        meta = json.loads(INPUT1)
+        # true case
+        meta['SentTimestamp'] = str(arrow.utcnow().timestamp)
+        self.assertTrue(self.filters.checkAllFilters(meta))
+        # fail sending site
+        meta['SendingSite'] = 'TEST3'
+        self.assertFalse(self.filters.checkAllFilters(meta))
+        # fail payload type
+        meta = json.loads(INPUT1)
+        meta['PayloadType'] = 'Report'
+        self.assertFalse(self.filters.checkAllFilters(meta))
+        # fail payload format
+        meta = json.loads(INPUT1)
+        meta['PayloadFormat'] = 'OtherPDF'
+        self.assertFalse(self.filters.checkAllFilters(meta))
+        # fail sensitivity
+        meta = json.loads(INPUT1)
+        meta['DataSensitivity'] = 'OUO'
+        self.assertFalse(self.filters.checkAllFilters(meta))
+        # fail restrictions
+        meta = json.loads(INPUT1)
+        meta['SharingRestrictions'] = 'AMBER'
+        self.assertFalse(self.filters.checkAllFilters(meta))
+        # fail recon policy
+        meta = json.loads(INPUT1)
+        meta['ReconPolicy'] = 'Touch'
+        self.assertFalse(self.filters.checkAllFilters(meta))
+        # fail file age
+        meta = json.loads(INPUT1)
+        meta['SentTimestamp'] = str(arrow.utcnow().shift(months=-2, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkAllFilters(meta))
+
+    def test_site_includes(self):
+        meta = json.loads(INPUT1)
+        # test site includes
+        self.assertTrue(self.filters.checkSendingSite(meta))
+        # test lower case
+        meta['SendingSite'] = 'TEST3'
+        self.assertFalse(self.filters.checkSendingSite(meta))
+        # test empty
+        self.filters._site_includes = []
+        self.assertTrue(self.filters.checkSendingSite(meta))
+
+    def test_site_excludes(self):
+        meta = json.loads(INPUT1)
+        self.filters._site_includes = []
+        # check includes empty and site not in excludes
+        self.assertTrue(self.filters.checkSendingSite(meta))
+        # check site in the excludes list
+        meta['SendingSite'] = 'SITE2'
+        self.assertFalse(self.filters.checkSendingSite(meta))
+        # check empty excludes list
+        self.filters._site_excludes = []
+        self.assertTrue(self.filters.checkSendingSite(meta))
+
+    def test_payload_types(self):
+        meta = json.loads(INPUT1)
+        # test type in the list
+        self.assertTrue(self.filters.checkPayloadType(meta))
+        # test unexpected list
+        meta['PayloadType'] = 'Report'
+        self.assertFalse(self.filters.checkPayloadType(meta))
+        # test empty list
+        self.filters._payload_types = []
+        self.assertTrue(self.filters.checkPayloadType(meta))
+
+    def test_payload_formats(self):
+        meta = json.loads(INPUT1)
+        # test format in the list
+        self.assertTrue(self.filters.checkPayloadFormat(meta))
+        # test unexpected list
+        meta['PayloadFormat'] = 'OtherPDF'
+        self.assertFalse(self.filters.checkPayloadFormat(meta))
+        # test empty list
+        self.filters._payload_formats = []
+        self.assertTrue(self.filters.checkPayloadFormat(meta))
+
+    def test_sensitivities(self):
+        meta = json.loads(INPUT1)
+        # test format in the list
+        self.assertTrue(self.filters.checkDataSensitivity(meta))
+        # test unexpected list
+        meta['DataSensitivity'] = 'OUO'
+        self.assertFalse(self.filters.checkDataSensitivity(meta))
+        # test empty list
+        self.filters._sensitivities = []
+        self.assertTrue(self.filters.checkDataSensitivity(meta))
+
+    def test_restrictions(self):
+        meta = json.loads(INPUT1)
+        # test format in the list
+        self.assertTrue(self.filters.checkSharingRestrictions(meta))
+        # test unexpected list
+        meta['SharingRestrictions'] = 'AMBER'
+        self.assertFalse(self.filters.checkSharingRestrictions(meta))
+        # test empty list
+        self.filters._restrictions = []
+        self.assertTrue(self.filters.checkSharingRestrictions(meta))
+
+    def test_reconn(self):
+        meta = json.loads(INPUT1)
+        # test format in the list
+        self.assertTrue(self.filters.checkReconPolicy(meta))
+        # test unexpected list
+        meta['ReconPolicy'] = 'Touch'
+        self.assertFalse(self.filters.checkReconPolicy(meta))
+        # test empty list
+        self.filters._reconnaissance = []
+        self.assertTrue(self.filters.checkReconPolicy(meta))
+
+    def test_no_file_age(self):
+        meta = json.loads(INPUT1)
+        # check no setting
+        self.filters._max_file_age = None
+        self.assertTrue(self.filters.checkFileAge(meta))
+
+    def test_file_age(self):
+        # utilizes tests for month
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(months=-2, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+    def test_file_age_sec(self):
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        self.filters._max_file_age = "30 secs"
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(seconds=-35).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+    def test_file_age_min(self):
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        self.filters._max_file_age = "30 min"
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(minutes=-30, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+    def test_file_age_hour(self):
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        self.filters._max_file_age = "1 hour"
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(hours=-1, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+    def test_file_age_day(self):
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        self.filters._max_file_age = "2 days"
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(days=-2, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+    def test_file_age_week(self):
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        self.filters._max_file_age = "1 week"
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(weeks=-1, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+    def test_file_age_yr(self):
+        meta = json.loads(INPUT1)
+        now = arrow.utcnow()
+        self.filters._max_file_age = "3 yrs"
+        meta['SentTimestamp'] = str(now.timestamp)
+        # check true
+        self.assertTrue(self.filters.checkFileAge(meta))
+        # check false
+        meta['SentTimestamp'] = str(now.shift(years=-3, seconds=-10).timestamp)
+        self.assertFalse(self.filters.checkFileAge(meta))
+
+
+if __name__ == '__main__':
+    main()

--- a/lqmt/test/readme.md
+++ b/lqmt/test/readme.md
@@ -29,3 +29,13 @@
     - [X] domains
     - [X] host
     - [X] url
+- [ ] Filter Configuration Validation
+    - [X] Site includes
+    - [X] Site excludes
+    - [X] Payload types
+    - [X] Payload formats
+    - [X] Sensitivities
+    - [X] Restrictions
+    - [X] Reconnaisance
+    - [X] Age of File
+    - [ ] File based (pre-parser) validation

--- a/lqmt/test/test_data/filters/filter_configs.py
+++ b/lqmt/test/test_data/filters/filter_configs.py
@@ -1,0 +1,11 @@
+TESTCONFIG1 = """
+[[Source.Filters]]
+    site_includes = [ 'SiTE1' ]
+    site_excludes = [ 'SitE2' ]
+    payload_types = [ 'alert' ]
+    payload_formats = [ 'STix' ]
+    sensitivities = [ 'nosensITIvity' ]
+    restrictions = [ 'whIte' ]
+    reconnaissance = [ 'notouch' ]
+    max_file_age = "2 mon"
+"""

--- a/lqmt/test/test_data/filters/filter_inputs.py
+++ b/lqmt/test/test_data/filters/filter_inputs.py
@@ -1,0 +1,9 @@
+INPUT1 = """{ 
+    "SendingSite": "SITE1", 
+    "SentTimestamp": "1502815271", 
+    "PayloadType": "Alert", 
+    "PayloadFormat": "STIX", 
+    "DataSensitivity": "noSensitivity", 
+    "SharingRestrictions": "WHITE", 
+    "ReconPolicy": "noTouch"
+}"""

--- a/lqmt/test/test_data/sample_config.py
+++ b/lqmt/test/test_data/sample_config.py
@@ -3,6 +3,16 @@ USERCONFIG = """
     dirs = [ "{0}" ]
     post_process = "nothing"
 
+[[Source.Filters]]
+    site_includes = [ ]
+    site_excludes = [ ]
+    payload_types = [ ]
+    payload_formats = [ ]
+    sensitivities = [ ]
+    restrictions = [ ]
+    reconnaissance = [ ]
+    max_file_age = "2 mon"
+
 [Logging]
   logfilebase = "{1}"
   debug = true

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
         'pan-python',
         'toml',
         'FlexTransform>=1.2.1',
-        'requests'
+        'requests',
+        'arrow'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Added meta-data based file filtering prior to sending a data file to a parser module.  The meta-data file parameters that allow filtering are SendingSite, PayloadType, PayloadFormat, DataSensitivity, SharingRestrictions, ReconPolicy, and SentTimestamp.  The implementation allows for each parameter to either be an empty list or nonexistent with no impact, the toml category is not required - this will maintain backwards compatibility.